### PR TITLE
Gitignore para la API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/backend/BrokerApi/.vs
+/.gitignore


### PR DESCRIPTION
GitIgnore configurado por VS para que no vea los cambios en la carpeta .vs de la API